### PR TITLE
feat(stats): display daily LLM token consumption

### DIFF
--- a/app/components/token-block.vue
+++ b/app/components/token-block.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import type { ChartData, ChartOptions } from "chart.js"
+import { Line as ChartLine } from "vue-chartjs"
+
+interface TabsItem {
+  label: string
+  value: string
+}
+
+type PeriodType = "1d" | "7d" | "30d" | "all"
+
+const periodTabItems = ref<TabsItem[]>([
+  { label: "24 часа", value: "1d" },
+  { label: "7 дней", value: "7d" },
+  { label: "30 дней", value: "30d" },
+  { label: "Все время", value: "all" },
+])
+const period = ref<PeriodType>("7d")
+
+const periodConfig: Record<PeriodType, { groupBy: string, daysBack?: number }> = {
+  "1d": { groupBy: "hour", daysBack: 1 },
+  "7d": { groupBy: "day", daysBack: 7 },
+  "30d": { groupBy: "day", daysBack: 30 },
+  "all": { groupBy: "week" },
+}
+
+const queryParams = computed(() => {
+  const config = periodConfig[period.value]
+  const now = new Date()
+  const params: Record<string, string> = { group_by: config.groupBy }
+  if (config.daysBack !== undefined) {
+    const start = new Date(now)
+    start.setDate(start.getDate() - config.daysBack)
+    params.start = start.toISOString()
+    params.end = now.toISOString()
+  }
+  return params
+})
+
+const { data: statsData } = await useApi("/api/v1/logs/token-stats", {
+  query: queryParams,
+})
+
+function formatLabel(isoDate: string, groupBy: string): string {
+  const date = new Date(isoDate)
+  if (groupBy === "hour") {
+    return date.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" })
+  }
+  if (groupBy === "day") {
+    return date.toLocaleDateString("ru-RU", { day: "numeric", month: "short" })
+  }
+  return date.toLocaleDateString("ru-RU", { month: "short", year: "numeric" })
+}
+
+function formatTokens(value: number): string {
+  return value.toLocaleString("ru-RU")
+}
+
+const { lineColor, ticksColor, gridColor } = useChartColors()
+
+const chartData = computed<ChartData<"line"> | null>(() => {
+  const buckets = statsData.value?.buckets
+  if (!buckets) {
+    return null
+  }
+  const groupBy = periodConfig[period.value].groupBy
+  return {
+    labels: buckets.map(b => formatLabel(b.period, groupBy)),
+    datasets: [{
+      data: buckets.map(b => b.tokens),
+      borderColor: lineColor.value,
+      borderWidth: 2,
+      tension: 0.3,
+      pointRadius: 0,
+    }],
+  }
+})
+
+const chartOptions = computed<ChartOptions<"line">>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: { display: false },
+    tooltip: {
+      callbacks: {
+        label: ctx => `${formatTokens(Number(ctx.parsed.y))} токенов`,
+      },
+    },
+  },
+  scales: {
+    x: {
+      ticks: { color: ticksColor.value },
+      grid: { display: false },
+      border: { display: false },
+    },
+    y: {
+      position: "right",
+      ticks: {
+        color: ticksColor.value,
+        callback: value => formatTokens(Number(value)),
+      },
+      grid: { color: gridColor.value },
+      border: { display: false },
+    },
+  },
+}))
+
+const totalTokens = computed(() => statsData.value?.total ?? 0)
+</script>
+
+<template lang="pug">
+ui-box(title="Потребление токенов" class="w-full")
+  div(class="mb-3 text-sm opacity-70")
+    | Всего за период: <b>{{ formatTokens(totalTokens) }}</b> токенов
+
+  div(class="h-64 w-full")
+    chart-line(v-if="chartData" :data="chartData" :options="chartOptions")
+
+  div(class="mt-4 overflow-x-auto")
+    u-tabs(
+      v-model="period"
+      :items="periodTabItems"
+      class="min-w-max"
+    )
+</template>

--- a/app/pages/stats.vue
+++ b/app/pages/stats.vue
@@ -2,6 +2,7 @@
 u-container(class="py-8")
   div(class="flex flex-col flex-wrap gap-6 lg:flex-row items-start")
     request-block
+    token-block
     topics-block
     question-block
     new-users-block

--- a/openapi.json
+++ b/openapi.json
@@ -911,6 +911,95 @@
         }
       }
     },
+    "/api/v1/logs/token-stats": {
+      "get": {
+        "tags": [
+          "Message Logs"
+        ],
+        "summary": "Статистика потребления токенов",
+        "description": "Возвращает суммарное потребление токенов LLM, сгруппированное по периодам.",
+        "operationId": "get_token_stats_api_v1_logs_token_stats_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Начало периода (ISO 8601)",
+              "title": "Start"
+            },
+            "description": "Начало периода (ISO 8601)"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Конец периода (ISO 8601)",
+              "title": "End"
+            },
+            "description": "Конец периода (ISO 8601)"
+          },
+          {
+            "name": "group_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Группировка: hour, day, week, month",
+              "default": "day",
+              "title": "Group By"
+            },
+            "description": "Группировка: hour, day, week, month"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenUsageStatsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/logs/": {
       "get": {
         "tags": [
@@ -3033,6 +3122,77 @@
         ],
         "title": "RequestCountStatsResponse",
         "description": "Статистика количества запросов за период времени."
+      },
+      "TokenUsageBucket": {
+        "properties": {
+          "period": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Period"
+          },
+          "tokens": {
+            "type": "integer",
+            "title": "Tokens"
+          }
+        },
+        "type": "object",
+        "required": [
+          "period",
+          "tokens"
+        ],
+        "title": "TokenUsageBucket",
+        "description": "Элемент статистики по количеству потраченных токенов."
+      },
+      "TokenUsageStatsResponse": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "group_by": {
+            "type": "string",
+            "title": "Group By"
+          },
+          "start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "buckets": {
+            "items": {
+              "$ref": "#/components/schemas/TokenUsageBucket"
+            },
+            "type": "array",
+            "title": "Buckets"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "group_by",
+          "buckets"
+        ],
+        "title": "TokenUsageStatsResponse",
+        "description": "Статистика потребления токенов LLM за период времени."
       },
       "TokenResponse": {
         "properties": {

--- a/types/openapi.d.ts
+++ b/types/openapi.d.ts
@@ -306,6 +306,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/logs/token-stats": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Статистика потребления токенов
+     * @description Возвращает суммарное потребление токенов LLM, сгруппированное по периодам.
+     */
+    get: operations["get_token_stats_api_v1_logs_token_stats_get"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/logs/": {
     parameters: {
       query?: never
@@ -1248,6 +1268,35 @@ export interface components {
       /** Buckets */
       buckets: components["schemas"]["RequestCountBucket"][]
     }
+    /**
+     * TokenUsageBucket
+     * @description Элемент статистики по количеству потраченных токенов.
+     */
+    TokenUsageBucket: {
+      /**
+       * Period
+       * Format: date-time
+       */
+      period: string
+      /** Tokens */
+      tokens: number
+    }
+    /**
+     * TokenUsageStatsResponse
+     * @description Статистика потребления токенов LLM за период времени.
+     */
+    TokenUsageStatsResponse: {
+      /** Total */
+      total: number
+      /** Group By */
+      group_by: string
+      /** Start */
+      start?: string | null
+      /** End */
+      end?: string | null
+      /** Buckets */
+      buckets: components["schemas"]["TokenUsageBucket"][]
+    }
     /** TokenResponse */
     TokenResponse: {
       /** Access Token */
@@ -2005,6 +2054,42 @@ export interface operations {
         }
         content: {
           "application/json": components["schemas"]["RequestCountStatsResponse"]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"]
+        }
+      }
+    }
+  }
+  get_token_stats_api_v1_logs_token_stats_get: {
+    parameters: {
+      query?: {
+        /** @description Начало периода (ISO 8601) */
+        start?: string | null
+        /** @description Конец периода (ISO 8601) */
+        end?: string | null
+        /** @description Группировка: hour, day, week, month */
+        group_by?: string
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["TokenUsageStatsResponse"]
         }
       }
       /** @description Validation Error */


### PR DESCRIPTION
Adds a token-block chart next to request-block on /stats, sourced from the new /api/v1/logs/token-stats endpoint, with the same 24h/7d/30d/all period selector and ru-RU number formatting.